### PR TITLE
Fail with a 404 when the reglement is not found

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,10 @@ app.get('/preview/regulatory-attachment/:uuid', async (req,res) => {
   `;
   const result = await query(myQuery);
   const bindings = result.results.bindings[0];
+  if(!bindings || !bindings.filename) {
+    res.status(404).end(); 
+    return;
+  }
   const filename = bindings.filename.value;
   const filePath = `/share/${filename}`;
   const content = fs.readFileSync(filePath, {encoding:'utf8', flag:'r'});
@@ -49,6 +53,10 @@ app.get('/preview/regulatory-attachment-container/:uuid', async (req,res) => {
   `;
   const result = await query(myQuery);
   const bindings = result.results.bindings[0];
+  if(!bindings || !bindings.filename) {
+    res.status(404).end(); 
+    return;
+  }
   const filename = bindings.filename.value;
   const filePath = `/share/${filename}`;
   const content = fs.readFileSync(filePath, {encoding:'utf8', flag:'r'});


### PR DESCRIPTION
When the reglement was not found the service was not responding, I changed it to give a 404 as it should, this will change when we remodel it to comply with JSON Api but at least it will stop weird behaviours 