### PR TITLE
GN-4323: Publish snippet to public space

### DIFF
--- a/util/common-sparql.js
+++ b/util/common-sparql.js
@@ -1,0 +1,60 @@
+import {sparqlEscapeUri,sparqlEscapeString} from 'mu';
+import {querySudo as query, updateSudo as update} from "@lblod/mu-auth-sudo";
+
+export const getPublishedVersion = async (documentContainerUri) => {
+  const publishedVersionQuery = `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
+      SELECT ?publishedContainer ?currentVersion
+      WHERE {
+        ?publishedContainer prov:derivedFrom ${sparqlEscapeUri(documentContainerUri)}.
+        ?publishedContainer  pav:hasCurrentVersion ?currentVersion.
+      }
+    `;
+
+  return await query(publishedVersionQuery);
+};
+
+export const hasPublishedVersion = (publishedVersionResults) => publishedVersionResults.results.bindings[0] && publishedVersionResults.results.bindings[0].publishedContainer;
+
+export const deletePublishedVersion = async (publishedVersionResults) => {
+  const publishedContainerUri = publishedVersionResults.results.bindings[0].publishedContainer.value;
+
+  const deleteCurrentVersionQuery = `
+        PREFIX pav: <http://purl.org/pav/>
+        DELETE WHERE {
+          GRAPH <http://mu.semte.ch/graphs/public> {
+            ${sparqlEscapeUri(publishedContainerUri)} pav:hasCurrentVersion ?currentVersion.
+          }
+        }
+      `;
+
+  await update(deleteCurrentVersionQuery);
+};
+
+/**
+ * @param {string} documentContainerUuid
+ */
+export const getEditorDocument = async (documentContainerUuid) => {
+  const documentContainerQuery = `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      SELECT ?documentContainer ?editorDocument ?graph ?title ?content
+      WHERE {
+        GRAPH ?graph {
+          ?documentContainer mu:uuid ${sparqlEscapeString(documentContainerUuid)};
+            pav:hasCurrentVersion ?editorDocument.
+          ?editorDocument dct:title ?title ;
+              ext:editorDocumentContent ?content ;
+              pav:createdOn ?createdOn .
+        }
+      }
+    `;
+
+  const result = await query(documentContainerQuery);
+  return result.results.bindings[0];
+};

--- a/util/snippet-sparql.js
+++ b/util/snippet-sparql.js
@@ -54,6 +54,7 @@ export const updatePublishedSnippetContainer = async ({
   await deletePublishedVersion(publishedVersionResults);
 
   const publishedContainerUri = publishedVersionResults.results.bindings[0].publishedContainer.value;
+  const previousVersionUri = publishedVersionResults.results.bindings[0].currentVersion.value;
 
   const snippetUuid = uuid();
   const publishedSnippetUri = `http://lblod.data.gift/published-snippets/${snippetUuid}`;
@@ -75,6 +76,7 @@ export const updatePublishedSnippetContainer = async ({
               dct:title ${sparqlEscapeString(title.value)};
               ext:editorDocumentContent ${sparqlEscapeString(content.value)};
               pav:createdOn ${sparqlEscapeDateTime(now)};
+              pav:previousVersion ${sparqlEscapeUri(previousVersionUri)};
               prov:derivedFrom ${sparqlEscapeUri(editorDocument.value)}.
           }
         }

--- a/util/snippet-sparql.js
+++ b/util/snippet-sparql.js
@@ -1,0 +1,84 @@
+import {sparqlEscapeDateTime, sparqlEscapeString, sparqlEscapeUri, uuid} from 'mu';
+import {updateSudo as update} from "@lblod/mu-auth-sudo";
+
+import {deletePublishedVersion} from "./common-sparql";
+
+export const insertPublishedSnippetContainer = async ({
+  documentContainer,
+  editorDocument,
+  title,
+  content,
+  publishingTaskUri
+}) => {
+  const snippetContainerUuid = uuid();
+  const snippetContainerUri = `http://lblod.data.gift/published-snippet-containers/${snippetContainerUuid}`;
+
+  const snippetUuid = uuid();
+  const publishedSnippetUri = `http://lblod.data.gift/published-snippets/${snippetUuid}`;
+  const now = new Date();
+
+  const insertPublishedVersionQuery = `
+        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+        PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+        PREFIX pav: <http://purl.org/pav/>
+        PREFIX dct: <http://purl.org/dc/terms/>
+        PREFIX prov: <http://www.w3.org/ns/prov#>
+        INSERT DATA {
+          GRAPH <http://mu.semte.ch/graphs/public> {
+            ${sparqlEscapeUri(publishingTaskUri)} ext:publishedVersion ${sparqlEscapeUri(publishedSnippetUri)}.
+            ${sparqlEscapeUri(snippetContainerUri)} a ext:PublishedSnippetContainer;
+              mu:uuid ${sparqlEscapeString(snippetContainerUuid)};
+              pav:hasCurrentVersion ${sparqlEscapeUri(publishedSnippetUri)};
+              pav:hasVersion ${sparqlEscapeUri(publishedSnippetUri)};
+              prov:derivedFrom ${sparqlEscapeUri(documentContainer.value)}.
+            ${sparqlEscapeUri(publishedSnippetUri)} a ext:PublishedSnippet;
+              mu:uuid ${sparqlEscapeString(snippetUuid)};
+              dct:title ${sparqlEscapeString(title.value)};
+              ext:editorDocumentContent ${sparqlEscapeString(content.value)};
+              pav:createdOn ${sparqlEscapeDateTime(now)};
+              prov:derivedFrom ${sparqlEscapeUri(editorDocument.value)}.
+          }
+        }
+      `;
+
+  await update(insertPublishedVersionQuery);
+};
+
+export const updatePublishedSnippetContainer = async ({
+  editorDocument,
+  title,
+  content,
+  publishingTaskUri,
+  publishedVersionResults,
+}) => {
+  await deletePublishedVersion(publishedVersionResults);
+
+  const publishedContainerUri = publishedVersionResults.results.bindings[0].publishedContainer.value;
+
+  const snippetUuid = uuid();
+  const publishedSnippetUri = `http://lblod.data.gift/published-snippets/${snippetUuid}`;
+  const now = new Date();
+
+  const updatePublishedVersionQuery = `
+        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+        PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+        PREFIX pav: <http://purl.org/pav/>
+        PREFIX dct: <http://purl.org/dc/terms/>
+        PREFIX prov: <http://www.w3.org/ns/prov#>
+        INSERT DATA {
+          GRAPH <http://mu.semte.ch/graphs/public> {
+            ${sparqlEscapeUri(publishingTaskUri)} ext:publishedVersion ${sparqlEscapeUri(publishedSnippetUri)}.
+            ${sparqlEscapeUri(publishedContainerUri)} pav:hasCurrentVersion ${sparqlEscapeUri(publishedSnippetUri)}.
+            ${sparqlEscapeUri(publishedContainerUri)} pav:hasVersion ${sparqlEscapeUri(publishedSnippetUri)}.
+            ${sparqlEscapeUri(publishedSnippetUri)} a ext:PublishedSnippet;
+              mu:uuid ${sparqlEscapeString(snippetUuid)};
+              dct:title ${sparqlEscapeString(title.value)};
+              ext:editorDocumentContent ${sparqlEscapeString(content.value)};
+              pav:createdOn ${sparqlEscapeDateTime(now)};
+              prov:derivedFrom ${sparqlEscapeUri(editorDocument.value)}.
+          }
+        }
+      `;
+
+  await update(updatePublishedVersionQuery);
+};

--- a/util/task-utils.js
+++ b/util/task-utils.js
@@ -1,16 +1,15 @@
 import Task from "../models/task";
 
 /**
- * @param meeting
+ * @param {string} documentContainerUri
  * @param {string} taskType
- * @param {string} [userUri]
  * */
-export async function ensureTask(reglementUri, userUri) {
-  let task = userUri
-    ? await Task.query({ reglementUri: reglementUri, userUri })
-    : await Task.query({ reglementUri: reglementUri });
+export async function ensureTask(documentContainerUri, taskType) {
+  let task = await Task.query({reglementUri: documentContainerUri, taskType});
+
   if (!task) {
-    task = await Task.create(reglementUri);
+    task = await Task.create(documentContainerUri, taskType);
   }
+
   return task;
 }


### PR DESCRIPTION
### Overview

Copies required `SnippetList` information to public graph, to enable querying from unauthorised frontends.

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4323


### Setup

1. Checkout https://github.com/lblod/reglement-publish-service/pull/10 for `reglement-publish-service/` repository
2. Checkout https://github.com/lblod/app-reglementaire-bijlage/pull/59 for `app-reglementaire-bijlage`
3. In the `app-reglementaire-bijlage` repo add a `docker-compose.extra.yml` file with content of
    ```docker
    version: "3.4"
    services:
      publisher:
        image: mu-javascript-template:latest
        links:
          - database:database
        environment:
          NODE_ENV: "development"
        volumes:
          - ./data/files/:/share/
          - /absolute/path/to/reglement-publish-service/:/app/
        restart: always
    ```
    note that `/absolute/path/to/reglement-publish-service/` should be an absolute path to where you have `frontend-reglementaire-bijlage` checked out.
4. In `app-reglementaire-bijlage` run

    ```sh
    docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.extra.yml up
    ```
    to bring the modified `app-reglementaire-bijlage` with modified `reglement-publish-service` up
5. Checkout https://github.com/lblod/frontend-reglementaire-bijlage/pull/136 for `frontend-reglementaire-bijlage`
6. Inside `frontend-reglementaire-bijlage` do `npm i` and server it with `ember s --proxy http://localhost`
7. Checkout https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/207 for `ember-rdfa-editor-lblod-plugins`
8. Inside `ember-rdfa-editor-lblod-plugins` do `npm i` and server it with `PORT=4300 npm run start`

### How to test/reproduce

Modified `frontend-reglementaire-bijlage` should be running on localhost on port 4200.
Modified `ember-rdfa-editor-lblod-plugins` should be running on localhost on port 4300.

* Go to http://localhost:4200/mock-login to login into RB frontend
* Create a Snippet List, and create a snippet within that list. Observe that all is working, snippet is saved and there are no console/network errors.
* Go to http://localhost:4300/regulatory-statement-sample (plugin test frontend)
* In the right sidebar click "Insert" and click "Insert snippet". Observe that snippets are visible and it is possible to insert them.
* Go back to RB frontend and update a snippet or create a new one
* Go back to Plugin frontend and observe that snippets are updated/created. It may take some time until SPARQL cache gets thrown and starts returning updates though.





