### PR TITLE
Introduce single `/tasks/:id` route used for fetching task information

### DIFF
--- a/app.js
+++ b/app.js
@@ -233,11 +233,11 @@ app.get('/tasks/:id', async function (req, res) {
         status: task.status,
         type: task.type,
       }
-    })
+    });
   } else {
     res.status(404).send(`task with id ${taskId} was not found`);
   }
-})
+});
 
 
 app.use(errorHandler);

--- a/app.js
+++ b/app.js
@@ -180,26 +180,6 @@ app.post('/regulatory-attachment-publication-tasks', async (req, res, next) => {
   }
 });
 
-app.get('/regulatory-attachment-publication-tasks/:id', async function (req, res) {
-  const taskUuid = req.params.id;
-  const task = await Task.find(taskUuid);
-  if (task) {
-    res.status(200).send({
-      data: {
-        id: task.id,
-        status: task.status,
-        type: task.type,
-        taskType: task.type,
-        relationships: {
-          "regulatory-attachment": task.regulatoryAttachmentPublication,
-        }
-      }
-    });
-  } else {
-    res.status(404).send(`task with id ${taskUuid} was not found`);
-  }
-});
-
 app.post('/snippet-list-publication-tasks', async (req, res, next) => {
   const documentContainerUuid = req.body.data.relationships['document-container'].data.id;
   const snippetListUuid = req.body.data.relationships['snippet-list'].data.id;
@@ -243,26 +223,21 @@ app.post('/snippet-list-publication-tasks', async (req, res, next) => {
   }
 });
 
-app.get('/snippet-list-publication-tasks/:id', async function (req, res) {
-  const taskUuid = req.params.id;
-  const task = await Task.find(taskUuid);
-
-  if (task) {
+app.get('/tasks/:id', async function (req, res) {
+  const taskId = req.params.id;
+  const task = await Task.find(taskId);
+  if(task){
     res.status(200).send({
       data: {
         id: task.id,
         status: task.status,
         type: task.type,
-        taskType: task.type,
-        relationships: {
-          "document-container": task.regulatoryAttachmentPublication,
-        }
       }
-    });
+    })
   } else {
-    res.status(404).send(`task with id ${taskUuid} was not found`);
+    res.status(404).send(`task with id ${taskId} was not found`);
   }
-});
+})
 
 
 app.use(errorHandler);


### PR DESCRIPTION
Visit https://github.com/lblod/app-reglementaire-bijlage/pull/78 for a summary of the changes included in this PR.