### PR TITLE
Generalize `task` interface

### DIFF
--- a/models/task.js
+++ b/models/task.js
@@ -78,7 +78,7 @@ export default class Task {
      PREFIX    dct: <http://purl.org/dc/terms/>
      PREFIX    adms: <http://www.w3.org/ns/adms#>
      PREFIX    ext: <http://mu.semte.ch/vocabularies/ext/>
-     SELECT ?uri ?uuid ?involves ?status ?modified ?created ?regulatoryAttachmentPublication WHERE {
+     SELECT ?uri ?uuid ?status ?modified ?created WHERE {
        ?uri a task:Task;
             mu:uuid ?uuid;
             dct:created ?created;

--- a/util/task-utils.js
+++ b/util/task-utils.js
@@ -1,14 +1,14 @@
 import Task from "../models/task";
 
 /**
- * @param {string} documentContainerUri
+ * @param {string} involves
  * @param {string} taskType
  * */
-export async function ensureTask(documentContainerUri, taskType) {
-  let task = await Task.query({reglementUri: documentContainerUri, taskType});
+export async function ensureTask(involves, taskType) {
+  let task = await Task.query({involves: involves, taskType});
 
   if (!task) {
-    task = await Task.create(documentContainerUri, taskType);
+    task = await Task.create(involves, taskType);
   }
 
   return task;


### PR DESCRIPTION
### Overview
This PR introduces some changes to the `Task` interface to make it more generic:
- removal of the `regulatoryAttachmentPublication`
- changes to the function signatures of the task methods/functions to make it more generic/less dependent on regulatory statement templates.