### PR TITLE
Fix crash when updating snippets from renamed SPARQL variable

### DIFF
--- a/util/snippet-sparql.js
+++ b/util/snippet-sparql.js
@@ -62,8 +62,8 @@ export const updatePublishedSnippetContainer = async ({
 }) => {
   await deletePublishedVersion(publishedVersionResults);
 
-  const publishedContainerUri =
-    publishedVersionResults.results.bindings[0].publishedContainer.value;
+  const templateUri =
+    publishedVersionResults.results.bindings[0].template.value;
   const previousVersionUri =
     publishedVersionResults.results.bindings[0].currentVersion.value;
 
@@ -82,7 +82,7 @@ export const updatePublishedSnippetContainer = async ({
           GRAPH <http://mu.semte.ch/graphs/public> {
             ${sparqlEscapeUri(publishingTaskUri)} ext:publishedVersion ${sparqlEscapeUri(publishedSnippetUri)}.
 
-            ${sparqlEscapeUri(publishedContainerUri)} pav:hasCurrentVersion ${sparqlEscapeUri(publishedSnippetUri)};
+            ${sparqlEscapeUri(templateUri)} pav:hasCurrentVersion ${sparqlEscapeUri(publishedSnippetUri)};
                                                       pav:hasVersion ${sparqlEscapeUri(publishedSnippetUri)};
                                                       ext:fromSnippetList ${sparqlEscapeUri(snippetList.value)}.
 


### PR DESCRIPTION
### Overview
Looks to have been introduced when moving to support decision templates (v5.0.0).

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Run as part of app-RB and save a modification to an existing snippet.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
