### PR TITLE
Only expire template versions that are already expired

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 import { app, errorHandler } from "mu";
+import { isAfter } from "date-fns/isAfter";
 import Task, {
   TASK_STATUS_FAILURE,
   TASK_STATUS_RUNNING,
@@ -74,7 +75,10 @@ app.post("/publish-template/:documentContainerId", async (req, res, next) => {
       templateType,
     });
     if (template.currentVersion) {
-      await template.currentVersion.markAsExpired();
+      const validThrough = template.currentVersion.validThrough;
+      if (!validThrough || isAfter(validThrough, Date.now())) {
+        await template.currentVersion.markAsExpired();
+      }
     }
     await template.setCurrentVersion(templateVersion);
     await publishingTask.updateStatus(TASK_STATUS_SUCCESS);

--- a/models/template-version.js
+++ b/models/template-version.js
@@ -16,16 +16,19 @@ export default class TemplateVersion {
   title;
   /** @type {string} */
   derivedFrom;
+  /** @type {Date | undefined} */
+  validThrough;
 
   /**
    *
-   * @param {{uri: string, id: string, title: string, derivedFrom: string}}
+   * @param {{uri: string, id: string, title: string, derivedFrom: string, validThrough?: Date}}
    */
-  constructor({ uri, id, title, derivedFrom }) {
+  constructor({ uri, id, title, derivedFrom, validThrough }) {
     this.uri = uri;
     this.id = id;
     this.title = title;
     this.derivedFrom = derivedFrom;
+    this.validThrough = validThrough;
   }
 
   /**
@@ -93,6 +96,8 @@ export default class TemplateVersion {
       id: binding.id.value,
       title: binding.title.value,
       derivedFrom: binding.derivedFrom.value,
+      validThrough:
+        binding.validThrough?.value && new Date(binding.validThrough.value),
     });
   }
   /**
@@ -112,13 +117,17 @@ export default class TemplateVersion {
       PREFIX gn: <http://data.lblod.info/vocabularies/gelinktnotuleren/>
       PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX schema: <http://schema.org/>
 
-      SELECT ?id ?uri ?title ?derivedFrom WHERE {
+      SELECT ?id ?uri ?title ?derivedFrom ?validThrough WHERE {
         ${bindStatement}
         ?uri a gn:TemplateVersie;
              mu:uuid ?id;
              dct:title ?title;
              prov:derivedFrom ?derivedFrom.
+        OPTIONAL {
+          ?uri schema:validThrough ?validThrough.
+        }
       }
     `;
     const result = await query(myQuery);

--- a/models/template.js
+++ b/models/template.js
@@ -68,6 +68,9 @@ export default class Template {
         id: binding.currentVersion_id.value,
         title: binding.currentVersion_title.value,
         derivedFrom: binding.currentVersion_derivedFrom.value,
+        validThrough:
+          binding.currentVersion_validThrough?.value &&
+          new Date(binding.currentVersion_validThrough.value),
       });
     }
     return new Template({
@@ -95,6 +98,7 @@ export default class Template {
       PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX pav: <http://purl.org/pav/>
       PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX schema: <http://schema.org/>
 
       SELECT 
         ?id 
@@ -104,6 +108,7 @@ export default class Template {
         ?currentVersion_id 
         ?currentVersion_title
         ?currentVersion_derivedFrom 
+        ?currentVersion_validThrough
       WHERE {
         ${bindStatement}
         ?uri a gn:Template;
@@ -114,6 +119,9 @@ export default class Template {
           ?currentVersion_uri mu:uuid ?currentVersion_id;
                               dct:title ?currentVersion_title;
                               prov:derivedFrom ?currentVersion_derivedFrom.
+        }
+        OPTIONAL {
+          ?currentVersion_uri schema:validThrough ?currentVersion_validThrough.
         }
       }
     `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lblod/mu-auth-sudo": "^0.6.0",
         "body-parser": "^1.20.0",
         "cors": "^2.8.5",
+        "date-fns": "^4.1.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3"
@@ -1688,6 +1689,16 @@
       "dev": true,
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -8658,6 +8669,11 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
       "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
       "dev": true
+    },
+    "date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@lblod/mu-auth-sudo": "^0.6.0",
     "body-parser": "^1.20.0",
     "cors": "^2.8.5",
+    "date-fns": "^4.1.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3"


### PR DESCRIPTION
### Overview
In the end wasn't actually that important, as the expiry process works anyway, just messes with history.

##### connected issues and PRs:
Part of unpublishing templates: https://github.com/lblod/frontend-reglementaire-bijlage/pull/305
Jira ticket: [binnenland.atlassian.net/browse/GN-5192](https://binnenland.atlassian.net/browse/GN-5192)

### Setup
Needs to be tested alongside template unpublishing support in order to be able to test different states.

### How to test/reproduce
Publishing a template works, and sets the expiry on the previous version if the template is live and just creates a new version if the previous version had been unpublished.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
