### PR TITLE
GN-5143: replace erroneous `prov:derivedFrom` by `prov:wasDerivedFrom`

### DIFF
--- a/.changeset/four-garlics-sin.md
+++ b/.changeset/four-garlics-sin.md
@@ -1,0 +1,5 @@
+---
+"reglement-publish-service": patch
+---
+
+Fix: replace erroneous `prov:derivedFrom` predicated by `prov:wasDerivedFrom`

--- a/models/template-version.js
+++ b/models/template-version.js
@@ -68,7 +68,7 @@ export default class TemplateVersion {
           nfo:fileSize ${fileSize};
           dbpedia:extension ${sparqlEscapeString("html")};
           nfo:fileCreated ${sparqlEscapeDateTime(now)};
-          prov:derivedFrom ${sparqlEscapeUri(derivedFrom)}.
+          prov:wasDerivedFrom ${sparqlEscapeUri(derivedFrom)}.
 
         ${sparqlEscapeUri(physicalFileUri)} 
           a nfo:FileDataObject;
@@ -123,7 +123,7 @@ export default class TemplateVersion {
         ?uri a gn:TemplateVersie;
              mu:uuid ?id;
              dct:title ?title;
-             prov:derivedFrom ?derivedFrom.
+             prov:wasDerivedFrom ?derivedFrom.
         OPTIONAL {
           ?uri schema:validThrough ?validThrough.
         }

--- a/models/template.js
+++ b/models/template.js
@@ -51,7 +51,7 @@ export default class Template {
       INSERT DATA {
         ${sparqlEscapeUri(templateUri)} a gn:Template;
                                         a ${sparqlEscapeUri(typeUri)};
-                                        prov:derivedFrom ${sparqlEscapeUri(derivedFrom)};
+                                        prov:wasDerivedFrom ${sparqlEscapeUri(derivedFrom)};
                                         mu:uuid ${sparqlEscapeString(templateId)}.
       }
     `;
@@ -116,12 +116,12 @@ export default class Template {
         ${bindStatement}
         ?uri a gn:Template;
              mu:uuid ?id;
-             prov:derivedFrom ?derivedFrom.
+             prov:wasDerivedFrom ?derivedFrom.
         OPTIONAL {
           ?uri pav:hasCurrentVersion ?currentVersion_uri.
           ?currentVersion_uri mu:uuid ?currentVersion_id;
                               dct:title ?currentVersion_title;
-                              prov:derivedFrom ?currentVersion_derivedFrom.
+                              prov:wasDerivedFrom ?currentVersion_derivedFrom.
         }
         OPTIONAL {
           ?currentVersion_uri schema:validThrough ?currentVersion_validThrough.


### PR DESCRIPTION
### Overview
This PR replaces the usage of the erroneous `prov:derivedFrom` predicate by `prov:wasDerivedFrom`.

##### connected issues and PRs:
[GN-5143](https://binnenland.atlassian.net/browse/GN-5143)
https://github.com/lblod/app-reglementaire-bijlage/pull/93

### How to test/reproduce
Check-out https://github.com/lblod/app-reglementaire-bijlage/pull/93 for more information


### Checks PR readiness
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
